### PR TITLE
Add a way to drop operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ processor := batch.StartProcessor(
 )
 
 // And use the processor inside http/grpc handler or technology-agnostic service.
-// ResourceKey can be taken from request parameter.
-err := processor.Run(resourceKey, func(r *YourResource) {
+// ctx is a standard context.Context and resourceKey can be taken from request parameter
+err := processor.Run(ctx, resourceKey, func(r *YourResource) {
     // Here you put the code which will executed sequentially inside batch  
 })
 ```

--- a/_example/http/http.go
+++ b/_example/http/http.go
@@ -4,6 +4,7 @@
 package http
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,7 +14,7 @@ import (
 )
 
 type TrainService interface {
-	Book(train string, seatNumber int, person string) error
+	Book(ctx context.Context, train string, seatNumber int, person string) error
 }
 
 func ListenAndServe(trainService TrainService) error {
@@ -41,7 +42,7 @@ func bookHandler(trainService TrainService) func(http.ResponseWriter, *http.Requ
 			return
 		}
 
-		err = trainService.Book(trainKey, seat, person)
+		err = trainService.Book(request.Context(), trainKey, seat, person)
 
 		if errors.Is(err, train.ErrValidation("")) {
 			writer.WriteHeader(http.StatusBadRequest)
@@ -51,7 +52,7 @@ func bookHandler(trainService TrainService) func(http.ResponseWriter, *http.Requ
 
 		if err != nil {
 			writer.WriteHeader(http.StatusInternalServerError)
-			fmt.Println("internal server error", err)
+			fmt.Println("internal server error:", err)
 			return
 		}
 

--- a/_example/train/service.go
+++ b/_example/train/service.go
@@ -3,19 +3,21 @@
 
 package train
 
+import "context"
+
 // BatchProcessor is an optional interface to decouple your code from `batch` package.
 type BatchProcessor interface {
-	Run(key string, operation func(*Train)) error
+	Run(ctx context.Context, key string, operation func(*Train)) error
 }
 
 type Service struct {
 	BatchProcessor BatchProcessor
 }
 
-func (s Service) Book(trainName string, seatNumber int, person string) error {
+func (s Service) Book(ctx context.Context, trainName string, seatNumber int, person string) error {
 	var operationError error
 
-	batchError := s.BatchProcessor.Run(trainName, func(train *Train) {
+	batchError := s.BatchProcessor.Run(ctx, trainName, func(train *Train) {
 		operationError = train.Book(seatNumber, person)
 	})
 

--- a/batch_bench_test.go
+++ b/batch_bench_test.go
@@ -1,6 +1,7 @@
 package batch_test
 
 import (
+	"context"
 	"strconv"
 	"sync"
 	"testing"
@@ -31,7 +32,7 @@ func BenchmarkProcessor_Run(b *testing.B) {
 				key := strconv.Itoa(i % resourceCount)
 				go func() {
 					// when
-					err := processor.Run(key, operation)
+					err := processor.Run(context.Background(), key, operation)
 					require.NoError(b, err)
 					allOperationsFinished.Done()
 				}()

--- a/error.go
+++ b/error.go
@@ -6,3 +6,4 @@ package batch
 import "errors"
 
 var ProcessorStopped = errors.New("run failed: processor is stopped")
+var OperationCancelled = errors.New("run failed: operation was canceled before it was run")


### PR DESCRIPTION
Client code executing Processor.Run might want to abort running operation if the operation was not yet run in a batch. Such situation is possible when there is a high request congestion.

From now on Processor.Run will accept new parameter context.Context. This context could be cancelled by the client effectively dropping the operation if it was still waiting to be run.

Example:

```
ctx := context.WithTimeout(context.Background(), 5 * time.Second)
err := processor.Run(ctx, "key", ...)
// err will be OperationCancelled
```

