### PR TITLE
[README] Remove information about using pessimistic lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ Normally a web application is using following pattern to modify data in the data
 1. **Load resource** from database. **Resource** is some portion of data 
 such as set of records from relational database, document from Document-oriented database or value from KV store
 (in Domain-Driven Design terms it is called an [aggregate](https://martinfowler.com/bliki/DDD_Aggregate.html)).
-Lock the entire resource pessimistically or optimistically (by reading version number).
+Lock the entire resource [optimistically](https://www.martinfowler.com/eaaCatalog/optimisticOfflineLock.html) 
+by reading version number.
 2. **Apply change** to data in plain Go
-3. **Save resource** to database. Release the pessimistic lock. Or run
-atomic update with version check (optimistic lock).
+3. **Save resource** to database. Release the lock by running
+atomic update with version check.
 
 But such architecture does not scale well if the number of requests 
 for a single resource is very high


### PR DESCRIPTION
Pessimistic locks are bad for high-throughput systems, because they require transactions, which in turn occupy database connections which have a great cost.

Pessimistic locks are especially bad when using batch processing, because batch operations takes significant amount of time (hundreds of millis). 